### PR TITLE
Fixes cmd result deadlocks

### DIFF
--- a/fsclientdemo/fsclientcdemo.go
+++ b/fsclientdemo/fsclientcdemo.go
@@ -57,7 +57,6 @@ func fsEventHandler() {
 	for {
 		event := <-fs.EventCh
 		fmt.Print("Action: '", event["Event-Name"], "'\n")
-
 		go apiHostname()
 
 		if event["Event-Name"] == "CHANNEL_PARK" {


### PR DESCRIPTION
- Fixes cmd result deadlocks by removing ability for cmdRes delivery to fail - it will now block until the app receives it. 
- Also cleans up reconnect code to ensure no API functions can be blocked when server disconnects
