### PR TITLE
Removes buffered event channel, and adds dynamic slice event buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 Freeswitch Event Socket Client
 
 This library is for connecting to the Freeswitch Event Socket and interacting with Freeswitch calls.
+
+Warning: v2.0 has a breaking API change in the `NewClient()` function to simplify usage.
+
+See https://github.com/tomponline/fsclient/blob/master/fsclient_demo/fsclient_demo.go for usage example.

--- a/fsclient/fsclient.go
+++ b/fsclient/fsclient.go
@@ -420,6 +420,8 @@ func (client *Client) handleAPIMsg(resp textproto.MIMEHeader) error {
 //NextEvent function blocks until there is an event recieved from Freeswitch.
 func (client *Client) NextEvent() map[string]string {
 	var event map[string]string
+	//Check there are no buffered events from earlier socket reads.
+	//If there are then deliver the earliest event from the buffer.
 	client.eventBufMu.Lock()
 	if len(client.eventBuf) > 0 {
 		event, client.eventBuf = client.eventBuf[0], client.eventBuf[1:]
@@ -427,5 +429,7 @@ func (client *Client) NextEvent() map[string]string {
 		return event
 	}
 	client.eventBufMu.Unlock()
+
+	//Otherwise block on event channel until a new event is available.
 	return <-client.eventCh
 }

--- a/fsclient/fsclient.go
+++ b/fsclient/fsclient.go
@@ -419,11 +419,11 @@ func (client *Client) handleAPIMsg(resp textproto.MIMEHeader) error {
 
 //NextEvent function blocks until there is an event recieved from Freeswitch.
 func (client *Client) NextEvent() map[string]string {
-	var event map[string]string
 	//Check there are no buffered events from earlier socket reads.
 	//If there are then deliver the earliest event from the buffer.
 	client.eventBufMu.Lock()
 	if len(client.eventBuf) > 0 {
+		var event map[string]string
 		event, client.eventBuf = client.eventBuf[0], client.eventBuf[1:]
 		client.eventBufMu.Unlock()
 		return event

--- a/fsclient/fsclient.go
+++ b/fsclient/fsclient.go
@@ -19,15 +19,17 @@ var logPrefix = "fsclient: "
 
 //Client represents a Freeswitch client. Contains the event socket connection.
 type Client struct {
-	eventConn *textproto.Conn
-	addr      string
-	password  string
-	cmdResCh  chan cmdRes
-	EventCh   chan map[string]string
-	filters   []string
-	subs      []string
-	connMu    *sync.Mutex
-	initFunc  func(*Client)
+	eventConn  *textproto.Conn
+	addr       string
+	password   string
+	cmdResCh   chan cmdRes
+	eventCh    chan map[string]string
+	eventBuf   []map[string]string
+	eventBufMu *sync.Mutex
+	filters    []string
+	subs       []string
+	connMu     *sync.Mutex
+	initFunc   func(*Client)
 }
 
 //cmdRes is a response structure for Freeswitch commands.
@@ -38,15 +40,17 @@ type cmdRes struct {
 }
 
 //NewClient creates a new Freeswitch client with filters, subscriptions and an init function.
-func NewClient(addr string, password string, filters []string, subs []string, eventBufSize int, initFunc func(*Client)) *Client {
+func NewClient(addr string, password string, filters []string, subs []string, initFunc func(*Client)) *Client {
 	fs := &Client{
-		addr:     addr,
-		password: password,
-		EventCh:  make(chan map[string]string, eventBufSize),
-		filters:  filters,
-		subs:     subs,
-		connMu:   &sync.Mutex{},
-		initFunc: initFunc,
+		addr:       addr,
+		password:   password,
+		eventCh:    make(chan map[string]string),
+		eventBuf:   make([]map[string]string, 0),
+		eventBufMu: &sync.Mutex{},
+		filters:    filters,
+		subs:       subs,
+		connMu:     &sync.Mutex{},
+		initFunc:   initFunc,
 	}
 
 	go fs.readHandler()
@@ -333,12 +337,12 @@ ConnectLoop:
 
 //deliverEvent sends an event to the EventCh channel, logs discarded messages.
 func (client *Client) deliverEvent(event map[string]string) {
-	chanLen := len(client.EventCh)
 	select {
-	case client.EventCh <- event:
-	case <-time.After(1 * time.Second): //Wait up to 1s to deliver to channel.
-		log.Print(logPrefix, "Error Event channel blocked (", chanLen,
-			" items), discarded Event: ", event["Unique-ID"], " ", event["Event-Name"])
+	case client.eventCh <- event:
+	default: //Buffer event to slice if can't be delivered immediately.
+		client.eventBufMu.Lock()
+		client.eventBuf = append(client.eventBuf, event)
+		client.eventBufMu.Unlock()
 	}
 }
 
@@ -411,4 +415,17 @@ func (client *Client) handleAPIMsg(resp textproto.MIMEHeader) error {
 	}
 	client.cmdResCh <- cmdRes{body: string(buf), err: err}
 	return err
+}
+
+//NextEvent function blocks until there is an event recieved from Freeswitch.
+func (client *Client) NextEvent() map[string]string {
+	var event map[string]string
+	client.eventBufMu.Lock()
+	if len(client.eventBuf) > 0 {
+		event, client.eventBuf = client.eventBuf[0], client.eventBuf[1:]
+		client.eventBufMu.Unlock()
+		return event
+	}
+	client.eventBufMu.Unlock()
+	return <-client.eventCh
 }

--- a/fsclient_bgapidemo/fsclient_bgapidemo.go
+++ b/fsclient_bgapidemo/fsclient_bgapidemo.go
@@ -22,7 +22,7 @@ func main() {
 		"BACKGROUND_JOB",
 	}
 
-	fs = fsclient.NewClient("127.0.0.1:8021", "ClueCon", filters, subs, 1, initFunc)
+	fs = fsclient.NewClient("127.0.0.1:8021", "ClueCon", filters, subs, initFunc)
 	go bgapiHostnameLoop()
 	fsEventHandler()
 }
@@ -51,7 +51,7 @@ func bgapiHostnameLoop() {
 
 func fsEventHandler() {
 	for {
-		event := <-fs.EventCh
+		event := fs.NextEvent()
 		fmt.Print("Action: '", event["Event-Name"], "'\n")
 
 		if event["Event-Name"] == "BACKGROUND_JOB" {

--- a/fsclient_demo/fsclient_demo.go
+++ b/fsclient_demo/fsclient_demo.go
@@ -26,7 +26,7 @@ func main() {
 		"CHANNEL_EXECUTE",
 	}
 
-	fs = fsclient.NewClient("127.0.0.1:8021", "ClueCon", filters, subs, 1, initFunc)
+	fs = fsclient.NewClient("127.0.0.1:8021", "ClueCon", filters, subs, initFunc)
 	go apiHostnameLoop()
 	fsEventHandler()
 }
@@ -55,7 +55,7 @@ func apiHostnameLoop() {
 
 func fsEventHandler() {
 	for {
-		event := <-fs.EventCh
+		event := fs.NextEvent()
 		fmt.Print("Action: '", event["Event-Name"], "'\n")
 		go apiHostname()
 

--- a/fsclient_demo/fsclient_demo.go
+++ b/fsclient_demo/fsclient_demo.go
@@ -43,7 +43,17 @@ func apiHostname() {
 		fmt.Println("API error: ", err)
 		return
 	}
-	fmt.Print("API response: ", hostname, "\n")
+	fmt.Print("Hostname API response: ", hostname, "\n")
+}
+
+func apiSleep() {
+	fmt.Println("Sending sleep command for 30s...")
+	hostname, err := fs.API("msleep 30000")
+	if err != nil {
+		fmt.Println("API error: ", err)
+		return
+	}
+	fmt.Print("Sleep API response: ", hostname, "\n")
 }
 
 func apiHostnameLoop() {
@@ -53,11 +63,20 @@ func apiHostnameLoop() {
 	}
 }
 
+func apiSomeSleep() {
+	for {
+		apiSleep()
+		time.Sleep(60 * time.Second)
+	}
+}
+
 func fsEventHandler() {
+	go apiHostname()
+	go apiSomeSleep()
+
 	for {
 		event := fs.NextEvent()
 		fmt.Print("Action: '", event["Event-Name"], "'\n")
-		go apiHostname()
 
 		if event["Event-Name"] == "CHANNEL_PARK" {
 			fmt.Println("Got channel park")

--- a/fsclient_yealinkdemo/fsclient_yealink_demo.go
+++ b/fsclient_yealinkdemo/fsclient_yealink_demo.go
@@ -23,7 +23,7 @@ func main() {
 		"NOTIFY",
 	}
 
-	fs = fsclient.NewClient("127.0.0.1:8021", "ClueCon", filters, subs, 1, initFunc)
+	fs = fsclient.NewClient("127.0.0.1:8021", "ClueCon", filters, subs, initFunc)
 	go eventGenerator()
 	fsEventHandler()
 }
@@ -98,7 +98,7 @@ func eventGenerator() {
 
 func fsEventHandler() {
 	for {
-		event := <-fs.EventCh
+		event := fs.NextEvent()
 		fmt.Print("Action: '", event["Event-Name"], "'\n")
 		if event["Event-Name"] == "NOTIFY" {
 			//Example of seeing the NOTIFY messages you generate with SendEvent().


### PR DESCRIPTION
removes buffered event channel, and adds a dynamic slice to buffer events.

Still a work in progress.

Addresses https://github.com/tomponline/fsclient/issues/6

Warning: This introduces a breaking API change in the new client function.

CC @gha